### PR TITLE
chore: set version of music21 to 9.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-music21
+music21==9.3.0
 black
 parameterized
 pandas

--- a/src/Part.py
+++ b/src/Part.py
@@ -24,7 +24,7 @@ class Part:
         return cls(part.id, voices)
 
 
-def extract_voices(part: Part21, voice_ids: List[str]):
+def extract_voices(part: Part21, voice_ids: List[str]) -> List[Voice]:
     part_data = {voice_id: [] for voice_id in voice_ids}
 
     for i, measure in enumerate(part.getElementsByClass(stream.Measure)):


### PR DESCRIPTION
the current version (9.9.0) changed how voices and their breaks are treated in a bar